### PR TITLE
Add clear button for ephemeral clipboard items

### DIFF
--- a/ClipKit/ClipboardManager.swift
+++ b/ClipKit/ClipboardManager.swift
@@ -213,7 +213,13 @@ class ClipboardManager: ObservableObject {
             saveEphemeralItems()
         }
     }
-    
+
+    // MARK: - Clear Ephemeral Items
+    func clearEphemeralItems() {
+        ephemeralItems.removeAll()
+        saveEphemeralItems()
+    }
+
     // MARK: - Save / Load Pinned Items
     private func savePinnedItems() {
         do {

--- a/ClipKit/ContentView.swift
+++ b/ClipKit/ContentView.swift
@@ -91,8 +91,16 @@ struct ContentView: View {
             Divider().padding(.vertical, 8)
 
             // ----- Ephemeral Section -----
-            Text("Recent (Ephemeral)")
-                .font(.headline)
+            HStack {
+                Text("Recent (Ephemeral)")
+                    .font(.headline)
+                Spacer()
+                Button(action: { clipboardManager.clearEphemeralItems() }) {
+                    Text("Clear")
+                }
+                .buttonStyle(.bordered)
+                .disabled(clipboardManager.ephemeralItems.isEmpty)
+            }
 
             let filteredEphemeral = clipboardManager.ephemeralItems
                 .filter { $0.matchesSearch(searchQuery) }


### PR DESCRIPTION
## Summary
- Add `clearEphemeralItems()` method to ClipboardManager
- Add Clear button next to the "Recent (Ephemeral)" section header
- Button is disabled when there are no ephemeral items to clear

## Test plan
- [x] Copy some text to clipboard multiple times
- [x] Verify items appear in ephemeral section
- [x] Click Clear button - all ephemeral items are removed
- [x] Verify button is disabled when list is empty