### PR TITLE
Fix ephemeral items exceeding limit when unpinning

### DIFF
--- a/ClipKit/ClipboardManager.swift
+++ b/ClipKit/ClipboardManager.swift
@@ -274,6 +274,7 @@ class ClipboardManager: ObservableObject {
             // optionally, re-add to ephemeral
             let ephemeralItem = ClipboardItem(content: item.content)
             ephemeralItems.insert(ephemeralItem, at: 0)
+            trimEphemeralItemsIfNeeded()
             savePinnedItems()
             saveEphemeralItems()
         }

--- a/ClipKitTests/ClipKitTests.swift
+++ b/ClipKitTests/ClipKitTests.swift
@@ -18,6 +18,10 @@ struct ClipKitTests {
 
         let manager = ClipboardManager(settings: settings)
 
+        // Clear any persisted state loaded from disk
+        manager.ephemeralItems.removeAll()
+        manager.pinnedItems.removeAll()
+
         // Fill ephemeral items to max capacity
         for i in 0..<maxCount {
             let item = ClipboardItem(content: .text("ephemeral-\(i)"))
@@ -49,6 +53,10 @@ struct ClipKitTests {
         settings.maxEphemeralCount = 0
 
         let manager = ClipboardManager(settings: settings)
+
+        // Clear any persisted state loaded from disk
+        manager.ephemeralItems.removeAll()
+        manager.pinnedItems.removeAll()
 
         // Add a pinned item
         let pinnedItem = ClipboardItem(content: .text("will-be-dropped"))

--- a/ClipKitTests/ClipKitTests.swift
+++ b/ClipKitTests/ClipKitTests.swift
@@ -10,8 +10,56 @@ import Testing
 
 struct ClipKitTests {
 
-    @Test func example() async throws {
-        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    @Test func unpinItemTrimsEphemeralToMaxCount() async throws {
+        // Setup: Create manager with a low maxEphemeralCount
+        let settings = SettingsManager()
+        let maxCount = 3
+        settings.maxEphemeralCount = maxCount
+
+        let manager = ClipboardManager(settings: settings)
+
+        // Fill ephemeral items to max capacity
+        for i in 0..<maxCount {
+            let item = ClipboardItem(content: .text("ephemeral-\(i)"))
+            manager.ephemeralItems.append(item)
+        }
+        #expect(manager.ephemeralItems.count == maxCount)
+
+        // Create and add a pinned item
+        let pinnedItem = ClipboardItem(content: .text("pinned-item"))
+        manager.pinnedItems.append(pinnedItem)
+        #expect(manager.pinnedItems.count == 1)
+
+        // Unpin the item - this should add to ephemeral and trim
+        manager.unpinItem(pinnedItem)
+
+        // Assert: ephemeral count should not exceed maxCount
+        #expect(manager.ephemeralItems.count <= maxCount,
+                "Ephemeral items exceeded max count after unpin: \(manager.ephemeralItems.count) > \(maxCount)")
+        #expect(manager.pinnedItems.count == 0, "Pinned item should be removed")
+
+        // Verify the unpinned item is at the top
+        #expect(manager.ephemeralItems.first?.content == .text("pinned-item"),
+                "Unpinned item should be at the top of ephemeral list")
+    }
+
+    @Test func unpinItemWithZeroMaxCountDropsItem() async throws {
+        // Edge case: maxEphemeralCount == 0 should immediately drop the item
+        let settings = SettingsManager()
+        settings.maxEphemeralCount = 0
+
+        let manager = ClipboardManager(settings: settings)
+
+        // Add a pinned item
+        let pinnedItem = ClipboardItem(content: .text("will-be-dropped"))
+        manager.pinnedItems.append(pinnedItem)
+
+        // Unpin - item gets added then immediately trimmed
+        manager.unpinItem(pinnedItem)
+
+        #expect(manager.ephemeralItems.count == 0,
+                "With maxEphemeralCount=0, ephemeral should be empty after unpin")
+        #expect(manager.pinnedItems.count == 0)
     }
 
 }


### PR DESCRIPTION
## Summary

- Fixes bug where `ephemeralItems` could exceed `maxEphemeralCount` when unpinning items
- Added `trimEphemeralItemsIfNeeded()` call in `unpinItem()` after inserting the item

## Problem

The `unpinItem` function was inserting items into `ephemeralItems` without calling `trimEphemeralItemsIfNeeded()`, allowing the count to exceed the configured limit until the next clipboard copy event.

Reported by Codex in PR #19.

## Test plan

- [ ] Set `maxEphemeralCount` to a low value (e.g., 5)
- [ ] Fill ephemeral history to the limit
- [ ] Pin an item, then unpin it
- [ ] Verify ephemeral count does not exceed the limit